### PR TITLE
Upgrade Fabric to Firebase Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,11 @@ android {
         debug {
             applicationIdSuffix ".debug"
             debuggable true
+            firebaseCrashlytics {
+                // If you don't need crash reporting for your debug build,
+                // you can speed up your build by disabling mapping file uploading.
+                mappingFileUploadEnabled false
+            }
         }
         release {
             shrinkResources true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'// Added Firebase Crashlytics plugin.
 
 
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -145,7 +145,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
     implementation 'com.google.firebase:firebase-messaging:20.1.3'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.0.0'// Added Firebase Crashlytics SDK.
     implementation 'com.google.firebase:firebase-analytics-ktx:17.3.0'
     implementation 'com.android.support:multidex:1.0.3'
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -76,8 +76,6 @@
 
 -keep public class * extends java.lang.Exception
 -keep class com.amazonaws.services.cognitoidentityprovider.** { *; }
--keep class com.crashlytics.** { *; }
--dontwarn com.crashlytics.**
 
 ### AWS
 # Class names are needed in reflection

--- a/app/src/main/java/nic/goi/aarogyasetu/CoronaApplication.java
+++ b/app/src/main/java/nic/goi/aarogyasetu/CoronaApplication.java
@@ -9,14 +9,13 @@ import androidx.annotation.NonNull;
 import androidx.work.Configuration;
 import androidx.work.WorkManager;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.LocationServices;
 import com.google.firebase.FirebaseApp;
 
 import java.util.List;
 import java.util.concurrent.Executors;
 
-import io.fabric.sdk.android.Fabric;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import nic.goi.aarogyasetu.utility.CorUtility;
 
 /**
@@ -43,7 +42,7 @@ public class CoronaApplication extends Application implements Configuration.Prov
                         .setExecutor(Executors.newFixedThreadPool(8))
                         .build());
         new Thread(() -> {
-            Fabric.with(CoronaApplication.getInstance(), new Crashlytics());
+            FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
         }).start();
 
     }

--- a/app/src/main/java/nic/goi/aarogyasetu/utility/CorUtility.kt
+++ b/app/src/main/java/nic/goi/aarogyasetu/utility/CorUtility.kt
@@ -25,7 +25,7 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
@@ -827,7 +827,7 @@ fun Exception?.reportException() {
     this?.let {
         if (!BuildConfig.DEBUG) {
             try {
-                Crashlytics.getInstance().core.logException(it)
+                FirebaseCrashlytics.getInstance().recordException(it);
             } catch (e: java.lang.Exception) {
                 //
             }

--- a/app/src/main/java/nic/goi/aarogyasetu/views/SplashActivity.kt
+++ b/app/src/main/java/nic/goi/aarogyasetu/views/SplashActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.security.ProviderInstaller
-import io.fabric.sdk.android.services.common.CommonUtils
+import com.google.firebase.crashlytics.internal.common.CommonUtils
 import nic.goi.aarogyasetu.BuildConfig
 import nic.goi.aarogyasetu.CoronaApplication
 import nic.goi.aarogyasetu.analytics.EventNames

--- a/build.gradle
+++ b/build.gradle
@@ -6,16 +6,12 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
-
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.31.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.1'// Added Firebase Crashlytics Gradle plugin.
     }
 }
 


### PR DESCRIPTION
Upgraded Fabric to Firebase Crashlytics since Fabric is already discontinued from 4th May 2020

Reference: https://firebase.google.com/docs/crashlytics/upgrade-sdk?platform=android