### PR TITLE
Removed unnecessary initialization of WorkManager at Application onCreate

### DIFF
--- a/app/src/main/java/nic/goi/aarogyasetu/CoronaApplication.java
+++ b/app/src/main/java/nic/goi/aarogyasetu/CoronaApplication.java
@@ -37,11 +37,6 @@ public class CoronaApplication extends Application implements Configuration.Prov
         super.onCreate();
         FirebaseApp.initializeApp(this);
         instance = this;
-        WorkManager.initialize(
-                this,
-                new Configuration.Builder()
-                        .setExecutor(Executors.newFixedThreadPool(8))
-                        .build());
         new Thread(() -> {
             Fabric.with(CoronaApplication.getInstance(), new Crashlytics());
         }).start();
@@ -100,8 +95,5 @@ public class CoronaApplication extends Application implements Configuration.Prov
     public Configuration getWorkManagerConfiguration() {
         return new Configuration.Builder().setExecutor(Executors.newFixedThreadPool(8)).build();
     }
-
-
-
 
 }


### PR DESCRIPTION
`CoronaApplication` class providing configuration for `WorkManager` via `Configuration.Provider` implementation and Auto initialization is disabled in `AndroidManifest.xml` using the following code,

```
<provider
            android:name="androidx.work.impl.WorkManagerInitializer"
            android:authorities="${applicationId}.workmanager-init"
            tools:node="remove" />
```

The application is using `WorkManager` in an on-demand fashion. Which initialize`WorkManager` at a required time using the configuration provided by `Configuration.Provider` implementation.

ArogyaSetu is calling `WorkManager` at 2 places using the following code,

```
WorkManager.getInstance(context)
WorkManager.getInstance(CoronaApplication.getInstance())
```

```
/**
     * Retrieves the {@code default} singleton instance of {@link WorkManager}.
     *
     * @param context A {@link Context} for on-demand initialization.
     * @return The singleton instance of {@link WorkManager}; this may be {@code null} in unusual
     *         circumstances where you have disabled automatic initialization and have failed to
     *         manually call {@link #initialize(Context, Configuration)}.
     * @throws IllegalStateException If WorkManager is not initialized properly
     */
    public static @NonNull WorkManager getInstance(@NonNull Context context) {
        return WorkManagerImpl.getInstance(context);
    }
```

Now, If you look at `WorkManagerImpl.getInstance(context)` method implementation,

```
public static @NonNull WorkManagerImpl getInstance(@NonNull Context context) {
        synchronized (sLock) {
            WorkManagerImpl instance = getInstance();
            if (instance == null) {
                Context appContext = context.getApplicationContext();
                if (appContext instanceof Configuration.Provider) {
                    initialize(
                            appContext,
                            ((Configuration.Provider) appContext).getWorkManagerConfiguration());
                    instance = getInstance(appContext);
                } else {
                    throw new IllegalStateException("WorkManager is not initialized properly.  You "
                            + "have explicitly disabled WorkManagerInitializer in your manifest, "
                            + "have not manually called WorkManager#initialize at this point, and "
                            + "your Application does not implement Configuration.Provider.");
                }
            }

            return instance;
        }
    }
``` 

So, It will automatically initialize `WorkManager` when required.  
