### PR TITLE
Remove redundant "android:screenOrientation = portrait" attribute in AppManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,15 +32,12 @@
 
 
         <activity
-            android:name="nic.goi.aarogyasetu.views.HomeActivity"
-            android:screenOrientation="portrait" />
+            android:name="nic.goi.aarogyasetu.views.HomeActivity"/>
         <activity
             android:name="nic.goi.aarogyasetu.views.OnboardingActivity"
-            android:launchMode="singleTask"
-            android:screenOrientation="portrait" />
+            android:launchMode="singleTask" />
         <activity
             android:name="nic.goi.aarogyasetu.views.SplashActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -62,17 +59,14 @@
         <activity
             android:name="nic.goi.aarogyasetu.views.PermissionActivity"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name="nic.goi.aarogyasetu.views.QrActivity"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name="nic.goi.aarogyasetu.zxing.CustomScannerActivity"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:stateNotNeeded="true"
             android:windowSoftInputMode="stateAlwaysHidden" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="colorPrimary">@color/black</item>
         <item name="colorPrimaryDark">@color/blue</item>
         <item name="colorAccent">@color/white</item>
+	<item name="android:screenOrientation">portrait</item>
         <item name="materialButtonStyle">@style/AppButton</item>
         <item name="textInputStyle">@style/AppTextField</item>
         <item name="android:textColorLink">@color/blue</item>
@@ -36,6 +37,7 @@
     <style name="AppTheme.Splash">
         <item name="android:statusBarColor">@color/white</item>
         <item name="android:windowBackground">@drawable/background_splash</item>
+        <item name="android:screenOrientation">portrait</item>
     </style>
 
     <style name="AppButton" parent="Widget.MaterialComponents.Button">


### PR DESCRIPTION
Remove redundant "android:screenOrientation = portrait" attribute each activity in AppManifest.xml instead define in AppTheme which is base
theme for all the activities. There is splash screen which actually overrides
AppTheme so provided standalone screenOrientation attrib to that one also.