### PR TITLE
Making the FightCovidDB singleton object creation synchronized

### DIFF
--- a/app/src/main/java/nic/goi/aarogyasetu/db/FightCovidDB.java
+++ b/app/src/main/java/nic/goi/aarogyasetu/db/FightCovidDB.java
@@ -17,15 +17,20 @@ import nic.goi.aarogyasetu.models.BluetoothData;
 @Database(entities = {BluetoothData.class}, version = 3)
 public abstract class FightCovidDB extends RoomDatabase {
 
-    private static FightCovidDB sInstance;
+    private volatile static FightCovidDB sInstance;
 
     private static final String DATABASE_NAME = "fight-covid-db";
 
     public static FightCovidDB getInstance() {
         Context context = CoronaApplication.getInstance().getApplicationContext();
         if (sInstance == null) {
-            sInstance = buildDatabase(context.getApplicationContext());
+            synchronized (FightCovidDB.class) {
+                if (sInstance == null) {
+                    sInstance = buildDatabase(context.getApplicationContext());
+                }
+            }
         }
+        
         return sInstance;
     }
 


### PR DESCRIPTION
The FightCovidDB Singleton object is can be accessed from different threads concurrently. So when creating the FightCovidDB object the first time, moved the object building logic inside synchronized block so multiple threads will have same database object.