### PR TITLE
[BugFix] Requests were not utilizing CONTENT_ENCODING

### DIFF
--- a/app/src/main/java/nic/goi/aarogyasetu/network/GzipRequestInterceptor.java
+++ b/app/src/main/java/nic/goi/aarogyasetu/network/GzipRequestInterceptor.java
@@ -16,7 +16,7 @@ import okio.Okio;
 class GzipRequestInterceptor implements Interceptor {
     @Override public Response intercept(Chain chain) throws IOException {
       Request originalRequest = chain.request();
-      if (originalRequest.body() == null || originalRequest.header(Constants.CONTENT_ENCODING) != null) {
+      if (originalRequest.body() == null || originalRequest.header(Constants.CONTENT_ENCODING) == null) {
         return chain.proceed(originalRequest);
       }
 


### PR DESCRIPTION
The condition was incorrect that was skipping CONTENT_ENCODING.