### PR TITLE
lint failure issue resolved

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,6 +106,7 @@ android {
 
     lintOptions {
         checkReleaseBuilds false
+        disable "InvalidPeriodicWorkRequestInterval"
         // Or, if you prefer, you can continue to check for errors in release builds,
         // but continue the build even when errors are found:
         abortOnError false


### PR DESCRIPTION
The crash seems to involve the detector androidx.work.lint.InvalidPeriodicWorkRequestIntervalDetector.