### PR TITLE
Added tools:ignore="LockedOrientationActivity" in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="LockedOrientationActivity">
 
 
         <activity


### PR DESCRIPTION
Since as a part of functionality app supports portrait orientation, so added tools:ignore="LockedOrientationActivity" in the manifest to remove the lint warning related to screen orientation.