### PR TITLE
Add Intent Action Check to Boot Reciever to Support the service from …

### DIFF
--- a/app/src/main/java/nic/goi/aarogyasetu/background/BootReceiver.kt
+++ b/app/src/main/java/nic/goi/aarogyasetu/background/BootReceiver.kt
@@ -15,9 +15,9 @@ import nic.goi.aarogyasetu.utility.CorUtility
 
 class BootReceiver : BroadcastReceiver() {
 
-    override fun onReceive(context: Context?, bootIntent: Intent?) {
+    override fun onReceive(context: Context?, intent: Intent?) {
         if (context == null) return
-        if (bootIntent?.action == Intent.ACTION_BOOT_COMPLETED
+        if (intent?.action == Intent.ACTION_BOOT_COMPLETED
                 || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")
                 || intent.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
             startService(context)

--- a/app/src/main/java/nic/goi/aarogyasetu/background/BootReceiver.kt
+++ b/app/src/main/java/nic/goi/aarogyasetu/background/BootReceiver.kt
@@ -18,8 +18,8 @@ class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context == null) return
         if (intent?.action == Intent.ACTION_BOOT_COMPLETED
-                || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")
-                || intent.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
+                || intent?.getAction().equals("android.intent.action.QUICKBOOT_POWERON")
+                || intent?.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
             startService(context)
         }
     }

--- a/app/src/main/java/nic/goi/aarogyasetu/background/BootReceiver.kt
+++ b/app/src/main/java/nic/goi/aarogyasetu/background/BootReceiver.kt
@@ -17,7 +17,9 @@ class BootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, bootIntent: Intent?) {
         if (context == null) return
-        if (bootIntent?.action == Intent.ACTION_BOOT_COMPLETED) {
+        if (bootIntent?.action == Intent.ACTION_BOOT_COMPLETED
+                || intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON")
+                || intent.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
             startService(context)
         }
     }


### PR DESCRIPTION
Add Intent Action Check to Boot Reciever to Support the service from being started on reboot and restart.
    
    - Intent android.intent.action.BOOT_COMPLETED is received after a "cold" boot.
    
    - Intent android.intent.action.QUICKBOOT_POWERON is received after a "restart" or a "reboot".
