### PR TITLE
better to remove unwanted attribute app:layout_constraint*

### DIFF
--- a/app/src/main/res/layout/fragment_select_language.xml
+++ b/app/src/main/res/layout/fragment_select_language.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -21,17 +20,13 @@
             android:gravity="center"
             android:paddingTop="10dp"
             android:text="@string/please_select_a_language_en"
-            app:layout_constraintBottom_toTopOf="@+id/rv_select_language"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_select_language"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_select_language_en" />
+            />
 
     </LinearLayout>
 


### PR DESCRIPTION
fix for https://github.com/nic-delhi/AarogyaSetu_Android/issues/461
Better to remove app:layout_constraint*
These attributes are for constraint layout.

Better to add tools:listitem="@layout/list_item_language" for recycler view to render layout during edit mode.