### PR TITLE
play core library version update to 1.7.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     //Firebase remote config
     implementation 'com.google.firebase:firebase-config:19.1.3'
 
-    implementation "com.google.android.play:core:1.6.0"
+    implementation "com.google.android.play:core:1.7.2"
     implementation 'com.journeyapps:zxing-android-embedded:3.3.0'
 
     // Testing dependencies


### PR DESCRIPTION
A local, arbitrary code execution vulnerability exists in the SplitCompat.install endpoint in Android's Play Core Library versions prior to 1.7.2. A malicious attacker could create an apk which targets a specific application, and if a victim were to install this apk, the attacker could perform a directory traversal, execute code as the targeted application and access the targeted application's data on the Android device. I believe that we are using the vulnerable play core version(1.6.0) in our android apk.so update the play core to the 1.7.2